### PR TITLE
Update set_profile_displayname to use UserID type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ sudo pip install git+https://github.com/ma1uta/matrix-synapse-rest-password-prov
 If the command fail, double check that the python version still matches. If not, please let us know by opening an issue.
 
 ## Configure
-Add or amend the `password_providers` entry like so:
+Add or amend the `modules` entry like so:
 ```yaml
-password_providers:
+modules:
   - module: "rest_auth_provider.RestAuthProvider"
     config:
       endpoint: "http://change.me.example.com:12345"
 ```
 Set `endpoint` to the value documented with the endpoint provider.
+
+**NOTE:** This requires Synapse 1.46 or later! If you migrate from the legacy `password_providers`, make sure
+to remove the old `RestAuthProvider` entry. If the `password_providers` list is empty, you can also remove it completely or
+comment it out.
 
 ## Use
 1. Install, configure, restart synapse

--- a/rest_auth_provider.py
+++ b/rest_auth_provider.py
@@ -26,6 +26,7 @@ import requests
 import time
 import synapse
 from synapse import module_api
+from synapse.types import UserID
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,9 @@ class RestAuthProvider(object):
             logger.info("User not authenticated")
             return False
 
+        types_user_id = UserID.from_string(user_id)
         localpart = user_id.split(":", 1)[0][1:]
+        domain = user_id.split(":", 1)[1][1:]
         logger.info("User %s authenticated", user_id)
 
         registration = False
@@ -117,7 +120,7 @@ class RestAuthProvider(object):
             if "display_name" in profile and ((registration and self.config.setNameOnRegister) or (self.config.setNameOnLogin)):
                 display_name = profile["display_name"]
                 logger.info("Setting display name to '%s' based on profile data", display_name)
-                await store.set_profile_displayname(localpart, display_name)
+                await store.set_profile_displayname(types_user_id, display_name)
             else:
                 logger.info("Display name was not set because it was not given or policy restricted it")
 


### PR DESCRIPTION
This is required as the function was updated to take this explicit type, rather than just the localpart, in https://github.com/matrix-org/synapse/pull/15458 as part of version 1.83.

This is stacked atop https://github.com/ma1uta/matrix-synapse-rest-password-provider/pull/10 to ensure everything is updated.